### PR TITLE
Add Ruby 2.4.0 and ruby-head in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 sudo: false
 language: ruby
 rvm:
+  - ruby-head
+  - 2.4.0
   - 2.3.3
   - 2.2
   - 2.1
   - 2.0
   - jruby
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
I want to add Ruby 2.4.0 and ruby-head to Travis.
The motivation and the detail is same with cucumber/cucumber-ruby#1087

This PR is same with below one. I mistook the repository to send PR.
https://github.com/cucumber/gherkin/pull/256

Thanks.
